### PR TITLE
fix: installer et maintenir Yumi_ANC comme les autres repos gérés

### DIFF
--- a/yumi_sync/yumi_sync.py
+++ b/yumi_sync/yumi_sync.py
@@ -382,14 +382,21 @@ MANAGED_REPOS = [
     {'name': 'moonraker-yumi-lab', 'path': '/home/pi/moonraker-yumi-lab', 'script': 'install.sh', 'args': ['-U', '-L']},       # V1
     {'name': 'moonraker-app-yumi-lab', 'path': '/home/pi/moonraker-app-yumi-lab', 'script': 'install.sh', 'args': ['-U', '-L']},  # V2
     {'name': 'Yumi-YMS-Manager', 'path': '/home/pi/Yumi-YMS-Manager', 'script': 'install.sh'},
+    {'name': 'Yumi_ANC', 'path': '/home/pi/Yumi_ANC', 'script': 'install.sh'},
 ]
 
-# === MAINSAIL → YMS-MANAGER DEPENDENCY ===
-# Yumi-YMS-Manager injects a JS script into Mainsail's static files.
-# When Moonraker updates Mainsail (web type = zip extract), the injection is lost.
-# Track Mainsail's index.html hash — if it changes, re-run YMS-Manager install.sh.
+# === MAINSAIL → INJECTOR DEPENDENCY ===
+# Some repos inject a <script> tag into Mainsail's index.html (YMS-Manager's
+# native panel, Yumi_ANC's native panel). When Moonraker updates Mainsail
+# (web type = zip extract) it replaces all static files and the injection is
+# lost. Track Mainsail's index.html hash — if it changes, re-run each
+# injector's install.sh so the tag (and the sidebar button) is re-added.
 MAINSAIL_INDEX = '/home/pi/mainsail/index.html'
 MAINSAIL_HASH_KEY = '_mainsail_index_hash'
+MAINSAIL_INJECTORS = [
+    {'name': 'Yumi-YMS-Manager', 'path': '/home/pi/Yumi-YMS-Manager'},
+    {'name': 'Yumi_ANC', 'path': '/home/pi/Yumi_ANC'},
+]
 
 def _load_install_state():
     try:
@@ -452,25 +459,27 @@ def repair_repos():
             logging.error("Repo %s: install.sh error: %s", repo['name'], e)
 
 
-def repair_mainsail_yms():
-    """Re-run Yumi-YMS-Manager install.sh when Mainsail has been updated.
+def repair_mainsail_injections():
+    """Re-run each Mainsail injector's install.sh when Mainsail has been updated.
 
     Mainsail is a web-type update (zip extract) — Moonraker replaces all static
-    files, which wipes the JS injection done by YMS-Manager.  We track the hash
-    of Mainsail's index.html; when it changes we re-execute the YMS installer.
+    files, which wipes the <script> tags injected into index.html by repos like
+    YMS-Manager and Yumi_ANC.  We track the hash of Mainsail's index.html; when
+    it changes we re-execute every installed injector so its panel/button is
+    re-added.
 
-    Safe no-op when Yumi-YMS-Manager is not installed.
+    Safe no-op when Mainsail or a given injector is not installed.  The tracked
+    hash is only advanced once ALL installed injectors succeed, so a transient
+    failure is retried on the next cycle.
     """
-    yms_path = '/home/pi/Yumi-YMS-Manager'
-    yms_script = os.path.join(yms_path, 'install.sh')
-
-    # Skip entirely if YMS-Manager is not installed on this machine
-    if not os.path.isfile(yms_script):
-        return
-
     # Skip if Mainsail is not installed
     if not os.path.isfile(MAINSAIL_INDEX):
         return
+
+    injectors = [i for i in MAINSAIL_INJECTORS
+                 if os.path.isfile(os.path.join(i['path'], 'install.sh'))]
+    if not injectors:
+        return  # no injector installed on this machine
 
     install_state = _load_install_state()
     current_hash = calculate_file_hash(MAINSAIL_INDEX)
@@ -481,33 +490,45 @@ def repair_mainsail_yms():
     if current_hash == saved_hash:
         return  # Mainsail unchanged
 
-    logging.info("Mainsail updated (index.html hash %s -> %s), re-running YMS-Manager install.sh...",
-                 saved_hash or 'NONE', current_hash)
-    try:
-        env = os.environ.copy()
-        env.update({
-            'HOME': '/home/pi',
-            'USER': 'pi',
-            'LOGNAME': 'pi',
-            'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        })
-        result = subprocess.run(
-            ['bash', 'install.sh'],
-            cwd=yms_path,
-            env=env,
-            capture_output=True, text=True, timeout=300
-        )
-        if result.returncode == 0:
-            logging.info("YMS-Manager re-installed after Mainsail update")
-            install_state[MAINSAIL_HASH_KEY] = current_hash
-            _save_install_state(install_state)
-        else:
-            logging.error("YMS-Manager reinstall failed (exit %d)\nstderr: %s",
-                          result.returncode, result.stderr[-500:] if result.stderr else '')
-    except subprocess.TimeoutExpired:
-        logging.error("YMS-Manager reinstall timed out (300s)")
-    except Exception as e:
-        logging.error("YMS-Manager reinstall error: %s", e)
+    logging.info("Mainsail updated (index.html hash %s -> %s), re-running %d injector(s)...",
+                 saved_hash or 'NONE', current_hash, len(injectors))
+
+    env = os.environ.copy()
+    env.update({
+        'HOME': '/home/pi',
+        'USER': 'pi',
+        'LOGNAME': 'pi',
+        'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    })
+
+    all_ok = True
+    for inj in injectors:
+        try:
+            result = subprocess.run(
+                ['bash', 'install.sh'],
+                cwd=inj['path'],
+                env=env,
+                capture_output=True, text=True, timeout=300
+            )
+            if result.returncode == 0:
+                logging.info("%s re-installed after Mainsail update", inj['name'])
+            else:
+                all_ok = False
+                logging.error("%s reinstall failed (exit %d)\nstderr: %s",
+                              inj['name'], result.returncode,
+                              result.stderr[-500:] if result.stderr else '')
+        except subprocess.TimeoutExpired:
+            all_ok = False
+            logging.error("%s reinstall timed out (300s)", inj['name'])
+        except Exception as e:
+            all_ok = False
+            logging.error("%s reinstall error: %s", inj['name'], e)
+
+    # Only remember this Mainsail revision once every injector re-applied
+    # cleanly; otherwise retry on the next cycle.
+    if all_ok:
+        install_state[MAINSAIL_HASH_KEY] = current_hash
+        _save_install_state(install_state)
 
 
 # === KLIPPER LEAD PATCH REPAIR ===
@@ -522,7 +543,7 @@ def repair_mainsail_yms():
 #
 # yumi-sync runs as ROOT, so it can re-copy the patched files and purge that
 # pycache where Moonraker (pi) hits "Permission denied".  Mirror of
-# repair_mainsail_yms: an external update wipes our patch -> detect drift by HASH
+# repair_mainsail_injections: an external update wipes our patch -> detect drift by HASH
 # (deployed klipper file vs yumi-config source) and re-apply.  Independent of
 # install.sh's hash, so it catches Klipper-side updates that repair_repos() never
 # sees.  Called both at startup and in the poll loop (with an anti-print guard) so
@@ -962,11 +983,11 @@ def main():
     except Exception as e:
         logging.error("Klipper lead repair failed: %s", e)
 
-    # Re-inject YMS-Manager into Mainsail if Mainsail was updated
+    # Re-inject Mainsail panels (YMS-Manager, ANC) if Mainsail was updated
     try:
-        repair_mainsail_yms()
+        repair_mainsail_injections()
     except Exception as e:
-        logging.error("Mainsail→YMS repair failed: %s", e)
+        logging.error("Mainsail injector repair failed: %s", e)
 
     state = load_state()
     previous_hash = state.get('last_hash')
@@ -1034,11 +1055,11 @@ def main():
                 except Exception as e:
                     logging.error("Send failed: %s", e)
 
-            # --- Mainsail → YMS-Manager re-injection ---
+            # --- Mainsail panel re-injection (YMS-Manager, ANC) ---
             try:
-                repair_mainsail_yms()
+                repair_mainsail_injections()
             except Exception as e:
-                logging.error("Mainsail→YMS check failed: %s", e)
+                logging.error("Mainsail injector check failed: %s", e)
 
             # --- Klipper lead patch re-apply (after a runtime klipper update) ---
             try:


### PR DESCRIPTION
## Problème (cause racine du bouton Calibration mort)
`Yumi_ANC` était absent de `MANAGED_REPOS`. Moonraker ne fait qu'un `git pull` — il n'exécute jamais les `install_script`. Donc sur un pad où l'ANC a été ajouté après le flash, l'`install.sh` n'a jamais tourné : la macro `ACOUSTIC_SPEED_SWEEP`, le `[include smartpad-anc.cfg]` et le panneau Mainsail n'ont jamais été mis en place → le bouton ne déclenchait rien.

## Correctifs
- Ajout de `Yumi_ANC` à `MANAGED_REPOS` : YUMI_SYNC exécute son `install.sh` au premier démarrage et à chaque changement de hash (comme yumi-config, YMS, etc.).
- Généralisation de la ré-injection Mainsail (avant YMS uniquement) vers une liste d'injecteurs, pour que le panneau natif ANC survive aux mises à jour web de Mainsail (sinon son `<script>` est effacé).

Le hash Mainsail n'est mémorisé que si **tous** les injecteurs réussissent → réessai au cycle suivant en cas d'échec transitoire. `py_compile` OK.